### PR TITLE
Fix install_svn and related functions

### DIFF
--- a/R/install-svn.R
+++ b/R/install-svn.R
@@ -9,35 +9,32 @@
 #'
 #' @inheritParams install_git
 #' @param subdir A sub-directory withing a svn repository that may contain the
-#'   package we are interested in installing. By default, this
-#'   points to the 'trunk' directory.
+#'   package we are interested in installing. 
 #' @param args A character vector providing extra arguments to pass on to
 #    svn.
 #' @param revision svn revision, if omitted updates to latest
-#' @param branch Name of branch or tag to use, if not trunk.
 #' @param ... Other arguments passed on to \code{install.packages}.
 #' @export
 #'
 #' @examples
 #' \dontrun{
-#' install_svn("https://github.com/hadley/stringr")
-#' install_svn("https://github.com/hadley/httr", branch = "oauth")
+#' install_svn("https://github.com/hadley/stringr/trunk")
+#' install_svn("https://github.com/hadley/httr/branches/oauth")
 #'}
-install_svn <- function(url, subdir = NULL, branch = NULL, args = character(0),
+install_svn <- function(url, subdir = NULL, args = character(0),
   ..., revision = NULL) {
 
-  remotes <- lapply(url, svn_remote, svn_subdir = subdir, branch = branch,
+  remotes <- lapply(url, svn_remote, svn_subdir = subdir,
     revision = revision, args = args)
 
   install_remotes(remotes, ...)
 }
 
-svn_remote <- function(url, svn_subdir = NULL, branch = NULL, revision = revision,
+svn_remote <- function(url, svn_subdir = NULL, revision = revision,
   args = character(0)) {
   remote("svn",
     url = url,
     svn_subdir = svn_subdir,
-    branch = branch,
     revision = revision,
     args = args
   )
@@ -51,17 +48,14 @@ remote_download.svn_remote <- function(x, quiet = FALSE) {
 
   bundle <- tempfile()
   svn_binary_path <- svn_path()
-
-  args <- c('co')
-  if (!is.null(x$branch)) {
-    url <- file.path(x$url, "branches", x$branch)
-  } else {
-    url <- file.path(x$url, "trunk")
-  }
+  url <- x$url
+  args <- "export"
+  if (!is.null(x$revision))
+    args <- paste("-r", x$revision, args)
   if (!is.null(x$svn_subdir)) {
     url <- file.path(url, x$svn_subdir);
-  }
-  args <- c(args, x$args, url, bundle)
+  } 
+  args <- c(x$args, args, url, bundle)
 
   message(shQuote(svn_binary_path), " ", paste0(args, collapse = " "))
   request <- system2(svn_binary_path, args, stdout = FALSE, stderr = FALSE)
@@ -69,16 +63,6 @@ remote_download.svn_remote <- function(x, quiet = FALSE) {
   # This is only looking for an error code above 0-success
   if (request > 0) {
     stop("There seems to be a problem retrieving this SVN-URL.", call. = FALSE)
-  }
-
-  if (!is.null(x$revision)) {
-    pwd <- setwd(bundle)
-    on.exit(setwd(pwd))
-
-    request <- system2(svn_binary_path, paste('update -r', x$revision))
-    if (request > 0) {
-      stop("There was a problem switching to the requested SVN revision", call. = FALSE)
-    }
   }
 
   bundle

--- a/man/install_svn.Rd
+++ b/man/install_svn.Rd
@@ -4,27 +4,24 @@
 \alias{install_svn}
 \title{Install a package from a SVN repository}
 \usage{
-install_svn(url, subdir = NULL, branch = NULL, args = character(0), ...,
+install_svn(url, subdir = NULL, args = character(0), ...,
   revision = NULL)
 }
 \arguments{
 \item{url}{Location of package. The url should point to a public or
 private repository.}
 
-\item{subdir}{A sub-directory withing a svn repository that may contain the
-package we are interested in installing. By default, this
-points to the 'trunk' directory.}
+\item{subdir}{A sub-directory withing a svn repository that contains the
+package we are interested in installing.}
 
-\item{branch}{Name of branch or tag to use, if not trunk.}
-
-\item{args}{A character vector providing extra arguments to pass on to}
+\item{args}{A character vector providing extra options to pass on to \command{svn}.}
 
 \item{...}{Other arguments passed on to \code{install.packages}.}
 
 \item{revision}{svn revision, if omitted updates to latest}
 }
 \description{
-This function requires \code{svn} to be installed on your system in order to
+This function requires \command{svn} to be installed on your system in order to
 be used.
 }
 \details{
@@ -33,8 +30,8 @@ a single command.
 }
 \examples{
 \dontrun{
-install_svn("https://github.com/hadley/stringr")
-install_svn("https://github.com/hadley/httr", branch = "oauth")
+install_svn("svn://github.com/hadley/stringr/trunk")
+install_svn("svn://github.com/hadley/httr/branches/oauth")
 }
 }
 


### PR DESCRIPTION
This fixes the bug in install_svn() that stops it from working with R-forge.  It no longer edits the URL, adding "trunk" or "branches" onto it.  

Since this makes it incompatible with the original, I also simplified things so they make more sense from an SVN point of view:  I dropped the "branch" argument, used "export" instead of "checkout", and chose the revision at time of export, rather than exporting the head and updating afterwards.