### PR TITLE
Suppress download.file() warnings

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -29,12 +29,14 @@ download <- function(path, url, auth_token = NULL, basic_auth = NULL,
 
 base_download <- function(url, path, quiet) {
 
-  status <- utils::download.file(
-    url,
-    path,
-    method = download_method(),
-    quiet = quiet,
-    mode = "wb"
+  suppressWarnings(
+    status <- utils::download.file(
+      url,
+      path,
+      method = download_method(),
+      quiet = quiet,
+      mode = "wb"
+    )
   )
 
   if (status != 0)  stop("Cannot download file from ", url, call. = FALSE)


### PR DESCRIPTION
occur e.g. when `install_github()` tries to access a missing `.gitmodules` file