### PR TITLE
URL-encode GitHub reference

### DIFF
--- a/R/install-github.R
+++ b/R/install-github.R
@@ -88,7 +88,7 @@ remote_download.github_remote <- function(x, quiet = FALSE) {
 
   dest <- tempfile(fileext = paste0(".zip"))
   src_root <- paste0("https://", x$host, "/repos/", x$username, "/", x$repo)
-  src <- paste0(src_root, "/zipball/", x$ref)
+  src <- paste0(src_root, "/zipball/", utils::URLencode(x$ref, reserved = TRUE))
 
   if (github_has_submodules(x)) {
     warning("GitHub repo contains submodules, may not function as expected!",

--- a/R/install-github.R
+++ b/R/install-github.R
@@ -256,7 +256,7 @@ parse_github_repo_spec <- function(repo) {
   params <- lapply(replace, function(r) gsub(github_rx, r, repo, perl = TRUE))
   if (params$invalid != "")
     stop(sprintf("Invalid git repo: %s", repo))
-  params <- params[sapply(params, nchar) > 0]
+  params <- params[viapply(params, nchar) > 0]
 
   params
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,6 +3,14 @@
 
 `%:::%` <- function (p, f) get(f, envir = asNamespace(p))
 
+vlapply <- function(X, FUN, ..., USE.NAMES = TRUE) {
+  vapply(X, FUN, logical(1L), ..., USE.NAMES = USE.NAMES)
+}
+
+viapply <- function(X, FUN, ..., USE.NAMES = TRUE) {
+  vapply(X, FUN, integer(1L), ..., USE.NAMES = USE.NAMES)
+}
+
 is_bioconductor <- function(x) {
   !is.null(x$biocviews)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,10 +3,6 @@
 
 `%:::%` <- function (p, f) get(f, envir = asNamespace(p))
 
-vlapply <- function(X, FUN, ..., USE.NAMES = TRUE) {
-  vapply(X, FUN, logical(1L), ..., USE.NAMES = USE.NAMES)
-}
-
 viapply <- function(X, FUN, ..., USE.NAMES = TRUE) {
   vapply(X, FUN, integer(1L), ..., USE.NAMES = USE.NAMES)
 }


### PR DESCRIPTION
in install_github().

Use case:

``` r
install_github("krlmlr/ranger/ranger-r-package/ranger@b-#118-dimnames")
```

(The dash in `#118` is the offender.)

Also affects devtools, CC @jimhester @hadley.
