### PR TITLE
Change default download method if needed

### DIFF
--- a/R/download.R
+++ b/R/download.R
@@ -50,15 +50,18 @@ download_method <- function() {
   if (compareVersion(get_r_version(), "3.3") == -1) {
     
     if (os_type() == "windows") {
-      return("wininet")
+      "wininet"
+      
+    } else if (isTRUE(unname(capabilities("libcurl")))) {
+      "libcurl"
+      
+    } else {
+      "auto"
+    }
     
-      } else if (isTRUE(unname(capabilities("libcurl")))) {
-      return("libcurl")
-    
-      }
+  } else {
+    "auto"
   }
-  
-  "auto"
 }
 
 curl_download <- function(url, path, quiet) {

--- a/R/download.R
+++ b/R/download.R
@@ -45,16 +45,20 @@ base_download <- function(url, path, quiet) {
 }
 
 download_method <- function() {
-
-  if (isTRUE(unname(capabilities("libcurl")))) {
-    "libcurl"
-
-  } else if (os_type() == "windows") {
-    "wininet"
-
-  } else {
-    "auto"
+  
+  # R versions newer than 3.3.0 have correct default methods
+  if (compareVersion(get_r_version(), "3.3") == -1) {
+    
+    if (os_type() == "windows") {
+      return("wininet")
+    
+      } else if (isTRUE(unname(capabilities("libcurl")))) {
+      return("libcurl")
+    
+      }
   }
+  
+  "auto"
 }
 
 curl_download <- function(url, path, quiet) {

--- a/inst/README.md
+++ b/inst/README.md
@@ -127,6 +127,18 @@ installed temporarily.
   and archived packages as well.
 * All dependencies of a package in a local directory via
   `install_deps`.
+  
+### Download methods
+
+* For R older the 3.2, `curl` package is required as `remotes` fallbacks to
+`curl::curl_download` in that case
+* For R newer than 3.3, default `download.file` method is used. (`method = "auto"`)
+* For in between version, 
+    * `method = "wininet"` is used on windows OS
+    * `method = "libcurl"` is used on other OS, if available.
+
+See `help("download.file")` for informations on these methods and for setting
+proxies if needed.
 
 ### Notes
 

--- a/tests/testthat/test-download.R
+++ b/tests/testthat/test-download.R
@@ -2,21 +2,29 @@
 context("Download")
 
 test_that("download_method", {
-
+  
   with_mock(
-    `base::capabilities` = function(...) c(libcurl = TRUE),
-    expect_equal(download_method(), "libcurl")
+    `remotes::get_r_version` = function(...) "3.3.0",
+    expect_equal(download_method(), "auto")
   )
 
   with_mock(
-    `base::capabilities` = function(...) c(libcurl = FALSE),
+    `remotes::get_r_version` = function(...) "3.2.5",
     `remotes::os_type` = function() "windows",
     expect_equal(download_method(), "wininet")
   )
 
   with_mock(
-    `base::capabilities` = function(...) c(libcurl = FALSE),
+    `remotes::get_r_version` = function(...) "3.2.5",
     `remotes::os_type` = function() "unix",
+    `base::capabilities` = function(...) c(libcurl = TRUE),
+    expect_equal(download_method(), "libcurl")
+  )
+
+  with_mock(
+    `remotes::get_r_version` = function(...) "3.2.5",
+    `remotes::os_type` = function() "unix",
+    `base::capabilities` = function(...) c(libcurl = FALSE),
     expect_equal(download_method(), "auto")
   )
 


### PR DESCRIPTION
This PR follows a discussion to resolve #45 . See issue post.

Based on some research about downloads method in R, I decided to modify `download_method` function in the following way

```
if R is older than 3.3, 
    if OS is windows
        set method to "wininet" 
    else on other OS if libcurl is avalaible, 
        set method to "libcurl"

For R 3.3 or newer, set method to "auto" the default
```

- Comparing with the previous function, I just reversed the checking (Windows before libcurl) and I rely on default R for newer than 3.3

- I noticed that for R older than 3.2.0, `curl_download` is used and `dowload_method` is not called. So I did not take care of this case. 
- If libcurl  is not available on non windows O, we rely on default method 

- I have modified the test to be compliant with the new function, and I have added some infos in Readme about download methods to point users toward `download.file` function help file.

- I did not change `intall-github.R` file as it seems you generated it by brew. 
- I did not add a bullet point in NEWS.md as it seems you have not done it before yet.

We could have done differently
* Modify default only for https url like in `downloader` package
* Mixed `base_download` and `curl_download` and deal with all that in `download` function as it is done in `downloader` function

Hope it is not too bad and I did not forgot anything
Tell me if something is not clear in what I have done 
